### PR TITLE
fixed env declaration in scale build

### DIFF
--- a/tasks/scale_build.yml
+++ b/tasks/scale_build.yml
@@ -31,7 +31,7 @@
 # Build kernel extension
 #
 - name: build | Compile kernel extension
-  shell: "LINUX_DISTRIBUTION = {{ scale_build_distribution }} ; /usr/lpp/mmfs/bin/mmbuildgpl --quiet"
+  shell: "export LINUX_DISTRIBUTION={{ scale_build_distribution }} ; /usr/lpp/mmfs/bin/mmbuildgpl --quiet"
   args:
     creates: /lib/modules/{{ ansible_kernel }}/extra/mmfs26.ko
 


### PR DESCRIPTION
The build task breaks like this without the fix:

`TASK [ansible-scale : build | Compile kernel extension] ******************************************************************************************************
fatal: [gpfs1n3]: FAILED! => {"changed": true, "cmd": "LINUX_DISTRIBUTION = REDHAT_AS_LINUX ; /usr/lpp/mmfs/bin/mmbuildgpl --quiet", "delta": "0:00:00.071936"
, "end": "2018-03-17 19:31:12.312506", "msg": "non-zero return code", "rc": 1, "start": "2018-03-17 19:31:12.240570", "stderr": "/bin/sh: LINUX_DISTRIBUTION:
Kommando nicht gefunden.\n\nCannot determine the distribution type.  /etc/redhat-release is present,\nbut the release name is not recognized.  Specify the dis
tribution\ntype explicitly.\n\n  e.g. LINUX_DISTRIBUTION=REDHAT_AS_LINUX \nmmbuildgpl: Command failed. Examine previous error messages to determine cause.", "
stderr_lines": ["/bin/sh: LINUX_DISTRIBUTION: Kommando nicht gefunden.", "", "Cannot determine the distribution type.  /etc/redhat-release is present,", "but
the release name is not recognized.  Specify the distribution", "type explicitly.", "", "  e.g. LINUX_DISTRIBUTION=REDHAT_AS_LINUX ", "mmbuildgpl: Command fai
led. Examine previous error messages to determine cause."], "stdout": "--------------------------------------------------------\nmmbuildgpl: Building GPL modu
le begins at Sa 17. Mär 19:31:12 CET 2018.\n--------------------------------------------------------", "stdout_lines": ["-------------------------------------
-------------------", "mmbuildgpl: Building GPL module begins at Sa 17. Mär 19:31:12 CET 2018.", "--------------------------------------------------------"]}`