### PR TITLE
Triggers and fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,11 +49,6 @@ scale_prepare_enable_ssh_login: true
 scale_prepare_disable_ssh_hostkeycheck: true
 
 
-## TODO In envrionment where security is allready handle.
-## this dont Exchange SSH keys, Disable SELinux, Enable SSH root login, Enable SSH pubkey authentication, Disable SSH hostkey checking
-## scale_prepare_secure_environment: true
-
-
 ## Path to public SSH key - will be generated (if it does not exist) and
 ## exchanged between nodes
 scale_prepare_pubkey_path: /root/.ssh/id_rsa.pub

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,22 @@ scale_reboot_automatic: false
 ## Whether or not to exchange SSH keys between nodes
 scale_prepare_exchange_keys: true
 
+## Whether or not to disable SELinux
+scale_prepare_selinux_disable: true
+
+## Whether or not enable SSH root login and Enable SSH pubkey authentication.
+scale_prepare_enable_ssh_login: true
+
+
+## Whether or not to Disable SSH hostkey checking.
+scale_prepare_disable_ssh_hostkeycheck: true
+
+
+## TODO In envrionment where security is allready handle.
+## this dont Exchange SSH keys, Disable SELinux, Enable SSH root login, Enable SSH pubkey authentication, Disable SSH hostkey checking
+## scale_prepare_secure_environment: true
+
+
 ## Path to public SSH key - will be generated (if it does not exist) and
 ## exchanged between nodes
 scale_prepare_pubkey_path: /root/.ssh/id_rsa.pub

--- a/tasks/scale_build.yml
+++ b/tasks/scale_build.yml
@@ -7,10 +7,9 @@
 #
     - name: build | Install prereqs for building GPL module from source
       yum:
-        name: "{{ item }}"
+        name: "{{ scale_build_gplsrc_prereqs }}"
         state: present
       when: ansible_pkg_mgr == 'yum'
-      with_items: "{{ scale_build_gplsrc_prereqs }}"
 
 #
 # Identify Linux Distribution

--- a/tasks/scale_install.yml
+++ b/tasks/scale_install.yml
@@ -68,11 +68,10 @@
 
     - name: install | Install GPFS RPMs
       yum:
-        name: "{{ item }}"
+        name: "{{ scale_install_all_rpms }}"
         state: present
       register: scale_install_rpmresult
       when: ansible_pkg_mgr == 'yum'
-      with_items: "{{ scale_install_all_rpms }}"
 
     - name: install | Check if GPFS RPMs were updated
       set_fact:

--- a/tasks/scale_prepare.yml
+++ b/tasks/scale_prepare.yml
@@ -1,10 +1,10 @@
 ---
 # Prepare node for installation
-
 - name: prepare | Disable SELinux
   selinux:
     state: disabled
   notify: reboot
+  when: scale_prepare_selinux_disable
 
 - name: prepare | Add Spectrum Scale directory to PATH
   lineinfile:
@@ -15,21 +15,23 @@
 #
 # Configure SSH server
 #
-- name: prepare | Enable SSH root login
-  lineinfile:
-    path: /etc/ssh/sshd_config
-    regexp: PermitRootLogin
-    line: PermitRootLogin yes
-    state: present
-  notify: reload-sshd
+- block:  ## when: scale_prepare_enable_ssh_login
+    - name: prepare | Enable SSH root login
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: PermitRootLogin
+        line: PermitRootLogin yes
+        state: present
+      notify: reload-sshd
 
-- name: prepare | Enable SSH pubkey authentication
-  lineinfile:
-    path: /etc/ssh/sshd_config
-    regexp: PubkeyAuthentication
-    line: PubkeyAuthentication yes
-    state: present
-  notify: reload-sshd
+    - name: prepare | Enable SSH pubkey authentication
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: PubkeyAuthentication
+        line: PubkeyAuthentication yes
+        state: present
+      notify: reload-sshd
+  when: scale_prepare_enable_ssh_login
 
 - meta: flush_handlers
 
@@ -42,7 +44,7 @@
     regexp: StrictHostKeyChecking
     line: StrictHostKeyChecking no
     state: present
-
+  when: scale_prepare_disable_ssh_hostkeycheck
 #
 # Exchange SSH keys
 #

--- a/tasks/scale_update.yml
+++ b/tasks/scale_update.yml
@@ -16,12 +16,13 @@
       vars:
         msg: |-
           ######################################################################
-          Spectrum Scale is running. Please stop it for an automatic offline
-          update, or manually perform an online update (by taking down one node
-          at a time)!
+          Spectrum Scale current version is "{{ scale_current_version.stdout }}" available version for upgrade "{{ scale_version }}"
+          Spectrum Scale is running, Please stop it for an automatic offline update,
+          or manually perform an online update (by taking down one node at a time)!
           ######################################################################
       assert:
         that:
           - true not in ansible_play_hosts | map('extract', hostvars, 'scale_install_needsupdate') | list
-        msg: "{{ msg.split('\n') }}"
+        msg: "{{ msg }}"
+        ##todo regression: assert msg no longer accepts list #48547 Another option to configure this is to add stdout_callback = debug to your ansible.cfg
   run_once: true


### PR DESCRIPTION
Created triggers for Scale_prepare for
Disable SELinux, Enable SSH root login, Enable SSH pubkey authentication, Disable SSH hostkey checking
Default is true.

Rerunn of playbooks ends in that MSG: Incorrect type for fail_msg or msg, expected string and got <type 'list'>
"assert msg no longer accepts list #48547 Another option to configure this is to add stdout_callback = debug to your ansible.cfg"
Change the msg under "update | Check if any running node needs to be updated" remove the split for "msg"

There was some error for installation of RPM:
Error: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name:
Change "install | Install GPFS RPMs"  "build | Install prereqs for building GPL module from source" to use name insted of with_item.