### PR TITLE
Fix: ansible throws error on assert msg of list

### DIFF
--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -24,5 +24,5 @@
       assert:
         that:
           - true not in ansible_play_hosts | map('extract', hostvars, 'scale_install_needsupdate') | list
-        msg: "{{ msg.split('\n') }}"
+        msg: "{{ msg }}"
   run_once: true


### PR DESCRIPTION
On CentOS 7 (Ansible 2.7.15) the assert message cannot be a list. Since the only purpose of breaking the message into a list is to make it prettier it seems hardly worth the cost. This small patch fixes this issue.